### PR TITLE
Update diag_ping.php

### DIFF
--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -39,9 +39,12 @@ require_once("guiconfig.inc");
 
 define('MAX_COUNT', 10);
 define('DEFAULT_COUNT', 3);
+define('MAX_WAIT', 10);
+define('DEFAULT_COUNT', 1);
 $do_ping = false;
 $host = '';
 $count = DEFAULT_COUNT;
+$wait = DEFAULT_WAIT;
 
 if ($_POST || $_REQUEST['host']) {
 	unset($input_errors);
@@ -55,7 +58,11 @@ if ($_POST || $_REQUEST['host']) {
 	if (($_REQUEST['count'] < 1) || ($_REQUEST['count'] > MAX_COUNT)) {
 		$input_errors[] = sprintf(gettext("Count must be between 1 and %s"), MAX_COUNT);
 	}
-
+	
+	if (($_REQUEST['wait'] < 1) || ($_REQUEST['wait'] > MAX_WAIT)) {
+		$input_errors[] = sprintf(gettext("Wait must be between 1 and %s"), MAX_WAIT);
+	}
+	
 	$host = trim($_REQUEST['host']);
 	$ipproto = $_REQUEST['ipproto'];
 	if (($ipproto == "ipv4") && is_ipaddrv6($host)) {
@@ -75,6 +82,10 @@ if ($_POST || $_REQUEST['host']) {
 		$count = $_REQUEST['count'];
 		if (preg_match('/[^0-9]/', $count)) {
 			$count = DEFAULT_COUNT;
+		}
+		$count = $_REQUEST['wait'];
+		if (preg_match('/[^0-9]/', wait)) {
+			$count = DEFAULT_WAIT;
 		}
 	}
 }
@@ -108,7 +119,7 @@ if ($do_ping) {
 		}
 	}
 
-	$cmd = "{$command} {$srcip} -c" . escapeshellarg($count) . " " . escapeshellarg($host);
+	$cmd = "{$command} {$srcip} -c" . escapeshellarg($count) . " -i " . escapeshellarg($wait) . " " . escapeshellarg($host);
 	//echo "Ping command: {$cmd}\n";
 	$result = shell_exec($cmd);
 
@@ -156,6 +167,13 @@ $section->addInput(new Form_Select(
 	$count,
 	array_combine(range(1, MAX_COUNT), range(1, MAX_COUNT))
 ))->setHelp('Select the maximum number of pings.');
+
+$section->addInput(new Form_Select(
+	'wait',
+	'Number of seconds to wait between pings',
+	$wait,
+	array_combine(range(1, MAX_WAIT), range(1, MAX_WAIT))
+))->setHelp('Select the number of seconds to wait between pings.');
 
 $form->add($section);
 


### PR DESCRIPTION
Add support for setting wait period between pings. 

https://www.freebsd.org/cgi/man.cgi?query=ping&sektion=8&apropos=0&manpath=FreeBSD+4.3-RELEASE
```
  -i wait
	     Wait wait seconds between sending each packet. The default is to
	     wait for one second between each packet.  The wait time may be
	     fractional, but only the super-user may specify values less then
	     1 second.	This option is incompatible with the -f option.
```

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review